### PR TITLE
Added jobs with non-developer version

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -20,12 +20,22 @@ jobs:
       submodules: false
       envs: |
         - linux: py311-asdf_astropy
+        - linux: py311-asdf_astropy-dev
         - linux: py311-astropy_healpix
+        - linux: py311-astropy_healpix-dev
         - linux: py311-astroquery
+        - linux: py311-astroquery-dev
         - linux: py311-ccdproc
+        - linux: py311-ccdproc-dev
         - linux: py311-photutils
+        - linux: py311-photutils-dev
         - linux: py311-regions
+        - linux: py311-regions-dev
         - linux: py311-reproject
+        - linux: py311-reproject-dev
         - linux: py311-specreduce
+        - linux: py311-specreduce-dev
         - linux: py311-specutils
+        - linux: py311-specutils-dev
         - linux: py311-sunpy
+        - linux: py311-sunpy-dev

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     # These are widely used packages that have historically
     # had issues with some astropy releases, so we include them here
     # as regression testing.
-    py{39,310,311,312}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}
+    py{39,310,311,312}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}{,-dev}
 
 requires =
     setuptools >= 30.3.0
@@ -24,19 +24,42 @@ pip_pre = true
 # side effects and make sure all test suites pass with all packages
 deps =
     astropy[all,test]
-    asdf_astropy,all: asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git
-    astropy_healpix,all: astropy_healpix[test] @ git+https://github.com/astropy/astropy-healpix.git
-    astroquery,all: astroquery[test,all] @ git+https://github.com/astropy/astroquery.git
+
+    asdf_astropy-!dev,all-!dev: asdf_astropy[test]
+    asdf_astropy-dev,all-dev: asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git
+
+    astropy_healpix-!dev,all-!dev: astropy_healpix[test]
+    astropy_healpix-dev,all-dev: astropy_healpix[test] @ git+https://github.com/astropy/astropy-healpix.git
+
+    astroquery-!dev,all-!dev: astroquery[test,all]
+    astroquery-dev,all-dev: astroquery[test,all] @ git+https://github.com/astropy/astroquery.git
+
     ccdproc,all: psutil
-    ccdproc,all: ccdproc[test,all] @ git+https://github.com/astropy/ccdproc.git
-    photutils,all: photutils[test,all] @ git+https://github.com/astropy/photutils.git
-    regions,all: regions[test,all] @ git+https://github.com/astropy/regions.git
-    reproject,all: reproject[test,all] @ git+https://github.com/astropy/reproject.git
-    specreduce,all: specreduce[test] @ git+https://github.com/astropy/specreduce.git
-    specutils,all: specutils[all,test] @ git+https://github.com/astropy/specutils.git#egg=
-    sunpy,all: sunpy[tests,all] @ git+https://github.com/sunpy/sunpy.git
+    ccdproc-!dev,all-!dev: ccdproc[test,all]
+    ccdproc-dev,all-dev: ccdproc[test,all] @ git+https://github.com/astropy/ccdproc.git
+
+    photutils-!dev,all-!dev: photutils[test,all]
+    photutils-dev,all-dev: photutils[test,all] @ git+https://github.com/astropy/photutils.git
+
+    regions-!dev,all-!dev: regions[test,all]
+    regions-dev,all-dev: regions[test,all] @ git+https://github.com/astropy/regions.git
+
+    reproject-!dev,all-!dev: reproject[test,all]
+    reproject-dev,all-dev: reproject[test,all] @ git+https://github.com/astropy/reproject.git
+
+    specreduce-!dev,all-!dev: specreduce[test]
+    specreduce-dev,all-dev: specreduce[test] @ git+https://github.com/astropy/specreduce.git
+
+    specutils-!dev,all-!dev: specutils[all,test]
+    specutils-dev,all-dev: specutils[all,test] @ git+https://github.com/astropy/specutils.git#egg=
+
+    sunpy-!dev,all-!dev: sunpy[tests,all]
+    sunpy-dev,all-dev: sunpy[tests,all] @ git+https://github.com/sunpy/sunpy.git
 
 skip_install = true
+
+allowlist_externals =
+    pip
 
 commands =
     pip freeze


### PR DESCRIPTION
This is to test if all releases/pre-releases work fine, e.g. current releases of coordinated packages with astropy pre-releases.