### PR TITLE
Pin numpy to 2.0.0rc1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ deps =
     sunpy-!dev,all-!dev: sunpy[tests,all]
     sunpy-dev,all-dev: sunpy[tests,all] @ git+https://github.com/sunpy/sunpy.git
 
+    numpy==2.0.0rc1
+
 skip_install = true
 
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ pip_pre = true
 # Note that we install all dependencies in all environments to catch any
 # side effects and make sure all test suites pass with all packages
 deps =
-    astropy[all,test]
+    astropy[test]
 
     asdf_astropy-!dev,all-!dev: asdf_astropy[test]
     asdf_astropy-dev,all-dev: asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git


### PR DESCRIPTION
Some packages are forcing numpy<2 to be installed, so pinning numpy to 2.0.0rc1 to see what works and what doesn't. Not for merging at this point!

### Where the wild things are

* asdf-astropy: https://github.com/astropy/asdf-astropy/pull/224
* astropy-healpix: https://github.com/astropy/astropy-healpix/pull/215
* ccdproc: https://github.com/astropy/ccdproc/issues/818
* photutils: https://github.com/astropy/photutils/pull/1717 and https://github.com/pydata/bottleneck/pull/445
* regions: https://github.com/astropy/regions/pull/545
* reproject: https://github.com/astropy/reproject/pull/436 and astropy-healpix fix above
* specreduce: Might be automatically fixed by photutils fix 🤷‍♀️ 
* specutils: https://github.com/astropy/specutils/pull/1130
* sunpy: https://github.com/sunpy/sunpy/issues/7555